### PR TITLE
Corriger : Duplicate explicit target name

### DIFF
--- a/doc/fr/gnu_parallel.rst
+++ b/doc/fr/gnu_parallel.rst
@@ -419,8 +419,9 @@ Pour en savoir plus
 -------------------
 
 - Documentation technique de l’Alliance : `GNU Parallel
-  <https://docs.alliancecan.ca/wiki/GNU_Parallel/fr>`_
+  <https://docs.alliancecan.ca/wiki/GNU_Parallel/fr>`__
 - Documentation officielle : `GNU Parallel
-  <https://www.gnu.org/software/parallel/sphinx.html>`_
-- Tutoriel : `GNU Parallel Tutorial
-  <https://www.gnu.org/software/parallel/parallel_tutorial.html>`_
+  <https://www.gnu.org/software/parallel/sphinx.html>`__
+
+  - Tutoriel : `GNU Parallel Tutorial
+    <https://www.gnu.org/software/parallel/parallel_tutorial.html>`_


### PR DESCRIPTION
Au moment de modifier cette partie dans la branche de construction, je n'avais pas vu le message `WARNING: Duplicate explicit target name: "gnu parallel"` lors de la compilation. Bref, les deux liens "GNU Parallel" au bas de la page étaient interprétés comme deux cibles identiques. En doublant le `_` à la fin de la syntaxe pour des liens externes, j'ai pu contourner le problème.

Ah oui, et j'ai aussi indenté le 3e point, car c'est finalement une page de la documentation officielle, donc ça fait partie du 2e point.