### PR TITLE
Post h25 révision

### DIFF
--- a/doc/en/gnu_parallel.rst
+++ b/doc/en/gnu_parallel.rst
@@ -387,21 +387,23 @@ processed with a maximum of two processes simultaneously:
     9
     10
 
-In an OpenMP job script containing:
+In a job script for an OpenMP program using 4 threads of execution:
 
 .. code-block:: bash
 
-    #SBATCH --nodes=1 --ntasks-per-node=16 --cpus-per-task=4
+    #!/bin/bash
 
-We would have a command like this:
+    #SBATCH --job-name=my-para-mt-job
+    #SBATCH --ntasks=1
+    #SBATCH --cpus-per-task=64
+    #SBATCH --time=1:00:00
+    #SBATCH --account=def-sponsor
 
-.. code-block:: bash
+    nthreads=4
+    export OMP_NUM_THREADS=$nthreads
+    njobs=$((SLURM_CPUS_PER_TASK / nthreads))
 
-    parallel \
-        -j $SLURM_NTASKS_PER_NODE \
-        --env OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK \
-        ./app <options> {} \
-        ::: val1 val2 ...
+    parallel --jobs $njobs ./app <options> {} ::: val1 val2 ...
 
 Find out more
 -------------

--- a/doc/en/job_arrays.rst
+++ b/doc/en/job_arrays.rst
@@ -112,7 +112,7 @@ Using job arrays
 
 The submitted jobs’ indices can be chosen freely. A few examples:
 
-- ``--array=1-10``: From 1 to 10
+- ``--array=0-10``: From 1 to 10
 - ``--array=1-9:2``: 1, 3, 5, 7, 9 (step of 2)
 - ``--array=1,2,5``: 1, 2, 5
 

--- a/doc/en/job_arrays.rst
+++ b/doc/en/job_arrays.rst
@@ -87,6 +87,12 @@ To cancel all jobs in the array:
 
     [alice@narval1 ~]$ scancel 40912550
 
+.. note::
+
+    Despite its name, the ``SLURM_ARRAY_TASK_ID`` variable has nothing to do
+    with parallelism options such as ``--ntasks`` or ``--ntasks-per-node``. It
+    only refers to a job’s index in an array.
+
 Exercise
 ''''''''
 

--- a/doc/en/job_arrays.rst
+++ b/doc/en/job_arrays.rst
@@ -118,7 +118,7 @@ Using job arrays
 
 The submitted jobs’ indices can be chosen freely. A few examples:
 
-- ``--array=0-10``: From 1 to 10
+- ``--array=0-10``: From 0 to 10 (11 jobs total)
 - ``--array=1-9:2``: 1, 3, 5, 7, 9 (step of 2)
 - ``--array=1,2,5``: 1, 2, 5
 

--- a/doc/en/other_tools.rst
+++ b/doc/en/other_tools.rst
@@ -120,7 +120,7 @@ Demonstration
 
 .. code-block:: console
 
-    [alice@narval3 ~]$ module load meta-farm/1.0.2
+    [alice@narval3 ~]$ module load meta-farm/1.0.3
 
 2. Create a farm
 ................
@@ -145,40 +145,39 @@ the farm and its cases.
 3. Configure the cases and the jobs
 ...................................
 
-The ``table.dat`` file lists the cases, one per line, with a case number in the
-first column.
+The ``table.dat`` file lists the cases, one per line. The default ``table.dat``
+contains 1300 cases. Each case calls the ``sleep`` command with a random
+argument.
 
 .. code-block:: console
 
-    [alice@narval3 hello]$ cat table.dat 
-    1 sleep 30
-    2 sleep 35
-    3 sleep 40
-    4 sleep 25
-    5 sleep 31
-    6 sleep 33
-    7 sleep 28
-    8 sleep 43
-    9 sleep 29
-    10 sleep 28
-    11 sleep 39
-    12 sleep 27
-    13 sleep 31
-    14 sleep 24
-    15 sleep 44
-    16 sleep 33
-    17 sleep 28
-    18 sleep 29
+    [alice@narval3 hello]$ wc -l table.dat 
+    1300 table.dat
+    [alice@narval3 hello]$ head table.dat 
+    sleep 26
+    sleep 26
+    sleep 28
+    sleep 30
+    sleep 29
+    sleep 25
+    sleep 25
+    sleep 28
+    sleep 27
+    sleep 29
 
-There are 18 cases in this example, which uses the default ``table.dat`` file.
-Each case calls the ``sleep`` command with a different argument.
+To simplify this example, we will retain only the first 18 cases.
+
+.. code-block:: console
+
+    [alice@narval3 hello]$ head -n 18 table.dat > subset.dat
+    [alice@narval3 hello]$ mv subset.dat table.dat
 
 File ``job_script.sh`` contains the ``#SBATCH`` instructions that will be
 applied to each of the :math:`N` jobs submitted to the scheduler. This file must
 be edited to at least set the required time and account to use. If your cases
 use a parallel or GPU program, request the necessary resources in this file.
 This example uses a serial program (``sleep``) that requires no particular
-resources:
+resources.
 
 .. code-block:: console
 
@@ -187,8 +186,9 @@ resources:
     #SBATCH --time=01:00:00
     #SBATCH --account=def-sponsor
 
-    # Don’t change this line:
-    task.run
+    # Don’t change the lines below
+    #=================================================================
+    [...]
 
 .. note::
 
@@ -206,16 +206,37 @@ resources:
 ..................
 
 The number of jobs :math:`N` is given to the META command ``submit.run``, which
-submits the jobs to the scheduler:
+submits the jobs to the scheduler.
 
 .. code-block:: console
 
     [alice@narval3 hello]$ submit.run 2
+    Submitting 20 cases from table.dat as 2 jobs using META mode
+
+    Submitting the farm as an Array Job
+
+    Success!
     [alice@narval3 hello]$ sq
               JOBID     USER      ACCOUNT           NAME  ST  TIME_LEFT NODES CPUS TRES_PER_N MIN_MEM NODELIST (REASON) 
          41169148_1    alice  def-sponsor          hello   R      59:10     1    1        N/A      4G nc31004 (None) 
          41169148_2    alice  def-sponsor          hello   R      59:10     1    1        N/A      4G nc31004 (None)
 
+The ``table.dat`` file is modified when the tasks are submitted, to set an index
+for each case.
+
+.. code-block:: console
+
+    [alice@narval3 hello]$ head table.dat
+    1 sleep 26
+    2 sleep 26
+    3 sleep 28
+    4 sleep 30
+    5 sleep 29
+    6 sleep 25
+    7 sleep 25
+    8 sleep 28
+    9 sleep 27
+    10 sleep 29
 
 5. Check results
 ................

--- a/doc/en/other_tools.rst
+++ b/doc/en/other_tools.rst
@@ -211,7 +211,7 @@ submits the jobs to the scheduler.
 .. code-block:: console
 
     [alice@narval3 hello]$ submit.run 2
-    Submitting 20 cases from table.dat as 2 jobs using META mode
+    Submitting 18 cases from table.dat as 2 jobs using META mode
 
     Submitting the farm as an Array Job
 

--- a/doc/fr/gnu_parallel.rst
+++ b/doc/fr/gnu_parallel.rst
@@ -397,21 +397,23 @@ forcer une limite sur le nombre de processus lancés à la fois. Par exemple,
     9
     10
 
-Dans un script de tâche OpenMP contenant :
+Dans un script de tâche pour un programme OpenMP utilisant 4 fils d’exécution :
 
 .. code-block:: bash
 
-    #SBATCH --nodes=1 --ntasks-per-node=16 --cpus-per-task=4
+    #!/bin/bash
 
-Nous aurions une commande comme celle-ci :
+    #SBATCH --job-name=my-para-mt-job
+    #SBATCH --ntasks=1
+    #SBATCH --cpus-per-task=64
+    #SBATCH --time=1:00:00
+    #SBATCH --account=def-sponsor
 
-.. code-block:: bash
+    nthreads=4
+    export OMP_NUM_THREADS=$nthreads
+    njobs=$((SLURM_CPUS_PER_TASK / nthreads))
 
-    parallel \
-        -j $SLURM_NTASKS_PER_NODE \
-        --env OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK \
-        ./app <options> {} \
-        ::: val1 val2 ...
+    parallel --jobs $njobs ./app <options> {} ::: val1 val2 ...
 
 Pour en savoir plus
 -------------------

--- a/doc/fr/job_arrays.rst
+++ b/doc/fr/job_arrays.rst
@@ -89,6 +89,12 @@ Ou encore toutes les tâches du vecteur :
 
     [alice@narval1 ~]$ scancel 40912550
 
+.. note::
+
+    Malgré son nom, la variable ``SLURM_ARRAY_TASK_ID`` n’a rien à voir avec les
+    options de parallélisme telles que ``--ntasks`` ou ``--ntasks-per-node``.
+    Elle réfère uniquement à l’index d’une tâche de calcul dans un vecteur.
+
 Exercice
 ''''''''
 

--- a/doc/fr/job_arrays.rst
+++ b/doc/fr/job_arrays.rst
@@ -116,7 +116,7 @@ Utiliser les vecteurs
 Les index des tâches à soumettre peuvent être contrôlés avec précision. Voici
 quelques exemples :
 
-- ``--array=1-10`` : De 1 à 10
+- ``--array=0-10`` : De 0 à 10
 - ``--array=1-9:2`` : 1, 3, 5, 7, 9 (un pas de 2)
 - ``--array=1,2,5`` : 1, 2, 5
 

--- a/doc/fr/job_arrays.rst
+++ b/doc/fr/job_arrays.rst
@@ -122,7 +122,7 @@ Utiliser les vecteurs
 Les index des tâches à soumettre peuvent être contrôlés avec précision. Voici
 quelques exemples :
 
-- ``--array=0-10`` : De 0 à 10
+- ``--array=0-10`` : De 0 à 10 (11 tâches au total)
 - ``--array=1-9:2`` : 1, 3, 5, 7, 9 (un pas de 2)
 - ``--array=1,2,5`` : 1, 2, 5
 

--- a/doc/fr/other_tools.rst
+++ b/doc/fr/other_tools.rst
@@ -219,7 +219,7 @@ soumet ces tâches à l’ordonnanceur.
 .. code-block:: console
 
     [alice@narval3 hello]$ submit.run 2
-    Submitting 20 cases from table.dat as 2 jobs using META mode
+    Submitting 18 cases from table.dat as 2 jobs using META mode
 
     Submitting the farm as an Array Job
 

--- a/doc/fr/other_tools.rst
+++ b/doc/fr/other_tools.rst
@@ -127,7 +127,7 @@ Démonstration
 
 .. code-block:: console
 
-    [alice@narval3 ~]$ module load meta-farm/1.0.2
+    [alice@narval3 ~]$ module load meta-farm/1.0.3
 
 2. Créer un groupe de cas
 .........................
@@ -152,40 +152,39 @@ configurer le groupe et les cas.
 3. Configurer les cas et les tâches
 ...................................
 
-Le fichier ``table.dat`` liste les cas, un par ligne, avec un numéro de cas dans
-la première colonne.
+Le fichier ``table.dat`` liste les cas, un par ligne. Le fichier généré par
+défaut contient 1300 cas. Chaque cas appelle la commande ``sleep`` avec un
+argument aléatoire.
 
 .. code-block:: console
 
-    [alice@narval3 hello]$ cat table.dat 
-    1 sleep 30
-    2 sleep 35
-    3 sleep 40
-    4 sleep 25
-    5 sleep 31
-    6 sleep 33
-    7 sleep 28
-    8 sleep 43
-    9 sleep 29
-    10 sleep 28
-    11 sleep 39
-    12 sleep 27
-    13 sleep 31
-    14 sleep 24
-    15 sleep 44
-    16 sleep 33
-    17 sleep 28
-    18 sleep 29
+    [alice@narval3 hello]$ wc -l table.dat 
+    1300 table.dat
+    [alice@narval3 hello]$ head table.dat 
+    sleep 26
+    sleep 26
+    sleep 28
+    sleep 30
+    sleep 29
+    sleep 25
+    sleep 25
+    sleep 28
+    sleep 27
+    sleep 29
 
-Il y a 18 cas dans cet exemple qui utilise le fichier ``table.dat`` créé par
-défaut. Chaque cas appelle la commande ``sleep`` avec un argument différent.
+Pour simplifier cet exemple, nous ne conserverons que les 18 premiers cas.
+
+.. code-block:: console
+
+    [alice@narval3 hello]$ head -n 18 table.dat > subset.dat
+    [alice@narval3 hello]$ mv subset.dat table.dat
 
 Le fichier ``job_script.sh`` contient les instructions ``#SBATCH`` qui seront
 appliquées à chacune des :math:`N` tâches soumises à l’ordonnanceur. Ce fichier
 doit être édité pour indiquer au moins le temps nécessaire et le compte à
 utiliser. Si vos cas utilisent un programme parallèle ou un GPU, demandez les
 ressources nécessaires dans ce fichier. Cet exemple utilise un programme sériel
-(``sleep``) qui ne demande aucune ressource particulière :
+(``sleep``) qui ne demande aucune ressource particulière.
 
 .. code-block:: console
 
@@ -194,8 +193,9 @@ ressources nécessaires dans ce fichier. Cet exemple utilise un programme série
     #SBATCH --time=01:00:00
     #SBATCH --account=def-sponsor
 
-    # Don’t change this line:
-    task.run
+    # Don’t change the lines below
+    #=================================================================
+    [...]
 
 .. note::
 
@@ -214,16 +214,37 @@ ressources nécessaires dans ce fichier. Cet exemple utilise un programme série
 .......................
 
 Le nombre :math:`N` de tâches est donné à la commande META ``submit.run``, qui
-soumet ces tâches à l’ordonnanceur :
+soumet ces tâches à l’ordonnanceur.
 
 .. code-block:: console
 
     [alice@narval3 hello]$ submit.run 2
+    Submitting 20 cases from table.dat as 2 jobs using META mode
+
+    Submitting the farm as an Array Job
+
+    Success!
     [alice@narval3 hello]$ sq
               JOBID     USER      ACCOUNT           NAME  ST  TIME_LEFT NODES CPUS TRES_PER_N MIN_MEM NODELIST (REASON) 
          41169148_1    alice  def-sponsor          hello   R      59:10     1    1        N/A      4G nc31004 (None) 
          41169148_2    alice  def-sponsor          hello   R      59:10     1    1        N/A      4G nc31004 (None)
 
+Le fichier ``table.dat`` est modifié lorsque les tâches sont soumises, afin
+d’assigner un index à chaque cas :
+
+.. code-block:: console
+
+    [alice@narval3 hello]$ head table.dat
+    1 sleep 26
+    2 sleep 26
+    3 sleep 28
+    4 sleep 30
+    5 sleep 29
+    6 sleep 25
+    7 sleep 25
+    8 sleep 28
+    9 sleep 27
+    10 sleep 29
 
 5. Consulter les résultats
 ..........................


### PR DESCRIPTION
Je vais aussi corriger l’exemple de GNU parallel dans le wiki, sur lequel notre exemple de parallel + OMP était basé. `--ntasks-per-node` est inapproprié puisqu’un seul processus `parallel` est lancé. L’option `--env`, pour sa part, ne permet pas de changer la valeur d’une variable d’environnement, seulement de propager une valeur existante.

L’exemple actuel dans le wiki fonctionne, plus ou moins, car il n’utilise pas `srun` et que `--ntasks-per-node` est donc ignoré. Par contre, il utilise le mauvais nombre de cœurs pour chaque « job » de `parallel` (vérifié sur un nœud de calcul).